### PR TITLE
13 ios 11 problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 ==========
+Version 0.1.5 *(2017-10-28)*
+----------------------------
+* Fix bug, crash on iOS 11 when targeting BarButtonItem and custom buttons were not displayed
+
 Version 0.1.4 *(2017-07-28)*
 ----------------------------
 * Fix bugs
@@ -15,8 +19,9 @@ Version 0.1.2 *(2017-05-25)*
 
 Version 0.1.1 *(2017-05-12)*
 ----------------------------
-* Fix Build settings  
+* Fix Build settings
 
 Version 0.1.0 *(2017-05-11)*
 ----------------------------
 * Initial release
+

--- a/MaterialShowcase.podspec
+++ b/MaterialShowcase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = 'MaterialShowcase'
-s.version          = '0.1.4'
+s.version          = '0.1.5'
 s.summary          = 'An elegant and beautiful showcase for iOS apps.'
 
 s.description      = <<-DESC

--- a/MaterialShowcase/Info.plist
+++ b/MaterialShowcase/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MaterialShowcase/MaterialShowcase.swift
+++ b/MaterialShowcase/MaterialShowcase.swift
@@ -255,7 +255,7 @@ extension MaterialShowcase {
   // Create a copy view of target view
   // It helps us not to affect the original target view
   private func addTarget(at center: CGPoint) {
-    targetCopyView = targetView.copyView() as! UIView
+    targetCopyView = targetView.snapshotView(afterScreenUpdates: true);
     targetCopyView.tintColor = targetTintColor
     
     if targetCopyView is UIButton {
@@ -441,11 +441,6 @@ public extension UIColor {
 
 // MARK: - UIView extension utility
 extension UIView{
-  
-  // Create a view's copy
-  func copyView() -> AnyObject{
-    return NSKeyedUnarchiver.unarchiveObject(with: NSKeyedArchiver.archivedData(withRootObject: self))! as AnyObject
-  }
   
   // Transform a view's shape into circle
   func asCircle(){


### PR DESCRIPTION
Implement fix suggested by https://github.com/Lokerfy.

Fixes crash on iOS 11 with barButtonItem #13 

Also, allows customButtonViews to be displayed properly (#5 #9) 