### PR TITLE
Added import UIKit statement & Changed targetView.copyView to targetView.snapshotView

### DIFF
--- a/MaterialShowcase/MaterialShowcase+Calculations.swift
+++ b/MaterialShowcase/MaterialShowcase+Calculations.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension MaterialShowcase {
 

--- a/MaterialShowcase/MaterialShowcase.swift
+++ b/MaterialShowcase/MaterialShowcase.swift
@@ -300,7 +300,6 @@ extension MaterialShowcase {
   /// Create a copy view of target view
   /// It helps us not to affect the original target view
   private func addTarget(at center: CGPoint) {
-//    targetCopyView = targetView.copyView()
     targetCopyView = targetView.snapshotView(afterScreenUpdates: true)
     
     if shouldSetTintColor {

--- a/MaterialShowcase/MaterialShowcase.swift
+++ b/MaterialShowcase/MaterialShowcase.swift
@@ -300,7 +300,8 @@ extension MaterialShowcase {
   /// Create a copy view of target view
   /// It helps us not to affect the original target view
   private func addTarget(at center: CGPoint) {
-    targetCopyView = targetView.copyView()
+//    targetCopyView = targetView.copyView()
+    targetCopyView = targetView.snapshotView(afterScreenUpdates: true)
     
     if shouldSetTintColor {
       targetCopyView.setTintColor(targetTintColor, recursive: true)

--- a/MaterialShowcase/MaterialShowcaseInstructionView.swift
+++ b/MaterialShowcase/MaterialShowcaseInstructionView.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public class MaterialShowcaseInstructionView: UIView {
   

--- a/MaterialShowcase/Utility.swift
+++ b/MaterialShowcase/Utility.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public extension UIColor {
   

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ You can define your own styles based on your app.
 If you have any issues or feedback, please visit [issue section](https://github.com/aromajoin/material-showcase-ios/issues).  
 Please feel free to create a pull request. 
 
+## Third Party Bindings
+
+### React Native
+You may now use this library with [React Native](https://github.com/facebook/react-native) via the module [here](https://github.com/prscX/react-native-material-showcase-ios)
+
+
 ## License  
 
 `Material Showcase` is available under the Apache license. See the LICENSE file for more info.


### PR DESCRIPTION
Hi @quangctkm9207,

As mentioned in query: [23](https://github.com/aromajoin/material-showcase-ios/issues/23#issuecomment-347011882), I have added this library in my RN Bridge Plugin library. Post adding I was getting below issues:

1. import UIKit issue
---

<img width="966" alt="screen shot 2017-11-27 at 1 58 12 pm" src="https://user-images.githubusercontent.com/28862892/33375608-793636b2-d530-11e7-8d1d-68e375e991eb.png">

Based on search suggestions, I have added ```import UIKit``` statement to below classes:
- MaterialShowcase/MaterialShowcase+Calculations.swift
- MaterialShowcase/Utility.swift
- MaterialShowcase/MaterialShowcaseInstructionView.swift

Post adding this I have tested both my plugin and this library, and both were working as expected.

2. Changed targetView.copyView to targetView.snapshotView
---
ReactNative does not allow to copy any views created by RN. I will getting below error

```
exception	NSException *	name: "RCTNotDesignatedInitializerException" - reason: "initWithCoder: is not implemented for the class RCTView"	0x000060000084c690
```

Based on search suggestion I have changed ```targetView.copyView to targetView.snapshotView```,  I am not sure what will be impact of this on standalone swift project, but I have verified this with by Objective-C project and is working as expected

Can you please merge this request. Please let me know in case any discussion is required for the same

Thanks
Pranav