### PR TITLE
Add Cocoapod script to Readme file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Material Showcase for iOS
 
 [![Download](https://img.shields.io/badge/pod-v0.5.1-blue.svg)](https://cocoapods.org/pods/MaterialShowcase)
-![CocoaPods downloaded](https://img.shields.io/cocoapods/dt/MaterialShowcase.svg)
-![CocoaPods installed](https://img.shields.io/cocoapods/at/MaterialShowcase.svg)
-![CocoaPods platforms](https://img.shields.io/cocoapods/p/MaterialShowcase.svg)
+[![CocoaPods downloaded](https://img.shields.io/cocoapods/dt/MaterialShowcase.svg)](https://cocoapods.org/pods/MaterialShowcase)
+[![CocoaPods installed](https://img.shields.io/cocoapods/at/MaterialShowcase.svg)](https://cocoapods.org/pods/MaterialShowcase)
+[![CocoaPods platforms](https://img.shields.io/cocoapods/p/MaterialShowcase.svg)](https://cocoapods.org/pods/MaterialShowcase)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg?style=flat-square)](https://www.apache.org/licenses/LICENSE-2.0.html)  
 
 **An elegant and beautiful tap showcase view for iOS apps based on Material Design Guidelines.**  

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After installing `MaterialShowcase` pod, please follow the below instructions to
 
 ![Objective-C showcase](https://raw.githubusercontent.com/Husseinhj/material-showcase-ios/fix/objc_property/art/ObjectiveCSupportScreenshot.png)
 
-** or **
+**OR**
 
 Add below Cocoapods script to your pod file :
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ After installing `MaterialShowcase` pod, please follow the below instructions to
 
 ![Objective-C showcase](https://raw.githubusercontent.com/Husseinhj/material-showcase-ios/fix/objc_property/art/ObjectiveCSupportScreenshot.png)
 
+** or **
+
+Add below Cocoapods script to your pod file :
+
+``` ruby
+# platform :ios, '9.0'
+
+target 'YOUR_PROJECT_NAME' do
+  use_frameworks!
+
+  pod 'MaterialShowcase'
+
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      if target.name.include?('MaterialShowcase')
+        target.build_configurations.each do |config|
+           config.build_settings['SWIFT_VERSION'] = '3.2'
+        end
+      end
+    end
+  end
+
+end
+```
+
 Using `#import "MaterialShowcase-Swift.h"` to import library to your class.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Material Showcase for iOS
 
 [![Download](https://img.shields.io/badge/pod-v0.5.1-blue.svg)](https://cocoapods.org/pods/MaterialShowcase)
+![CocoaPods downloaded](https://img.shields.io/cocoapods/dt/MaterialShowcase.svg)
+![CocoaPods installed](https://img.shields.io/cocoapods/at/MaterialShowcase.svg)
+![CocoaPods platforms](https://img.shields.io/cocoapods/p/MaterialShowcase.svg)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg?style=flat-square)](https://www.apache.org/licenses/LICENSE-2.0.html)  
 
 **An elegant and beautiful tap showcase view for iOS apps based on Material Design Guidelines.**  


### PR DESCRIPTION
When I use `MaterialShowcase` in my **Objective-C** project and want to update/add new pod, Every time I should fix swift version config. So now in find out Cococapod script to change `SWIFT_VERSION` automatically. 


Add to [Awesome iOS](https://github.com/vsouza/awesome-ios#walkthrough--intro--tutorial) repo.