### PR TITLE
Allowing targetView to be shown through backgroundView rather than a snapshot

### DIFF
--- a/MaterialShowcase/MaterialShowcase.swift
+++ b/MaterialShowcase/MaterialShowcase.swift
@@ -252,7 +252,11 @@ extension MaterialShowcase {
     
     addTargetRipple(at: center)
     addTargetHolder(at: center)
-    addTarget(at: center)
+    
+    // if color is not UIColor.clear, then add the target snapshot
+    if targetHolderColor != .clear {
+      addTarget(at: center)
+    }
     
     //In iPad version InstructionView was add to backgroundView
     if UIDevice.current.userInterfaceIdiom == .pad {
@@ -270,7 +274,7 @@ extension MaterialShowcase {
     // Disable subview interaction to let users click to general view only
     subviews.forEach({$0.isUserInteractionEnabled = false})
     
-    if isTapRecognizerForTagretView {
+    if isTapRecognizerForTagretView && targetHolderColor != .clear{
       //Add gesture recognizer for targetCopyView
       targetCopyView.addGestureRecognizer(tapGestureRecoganizer())
       targetCopyView.isUserInteractionEnabled = true
@@ -287,12 +291,12 @@ extension MaterialShowcase {
     case .circle:
       let radius: CGFloat!
       
-      let center = targetCopyView.center//getOuterCircleCenterPoint(for: targetCopyView)
+      let center = targetRippleView.center//getOuterCircleCenterPoint(for: targetCopyView)
       
       if UIDevice.current.userInterfaceIdiom == .pad {
         radius = 300.0
       } else {
-        radius = getOuterCircleRadius(center: center, textBounds: instructionView.frame, targetBounds: targetCopyView.frame)
+        radius = getOuterCircleRadius(center: center, textBounds: instructionView.frame, targetBounds: targetRippleView.frame)
       }
       
       backgroundView = UIView(frame: CGRect(x: 0, y: 0, width: radius * 2,height: radius * 2))
@@ -304,6 +308,22 @@ extension MaterialShowcase {
     }
     backgroundView.backgroundColor = backgroundPromptColor.withAlphaComponent(backgroundPromptColorAlpha)
     insertSubview(backgroundView, belowSubview: targetRippleView)
+    addBackgroundMask(with: targetHolderRadius, in: backgroundView)
+
+  }
+  
+  private func addBackgroundMask(with radius: CGFloat, in view: UIView) {
+    
+    let center = backgroundViewType == .circle ? view.bounds.center : targetRippleView.center
+    let mutablePath = CGMutablePath()
+    mutablePath.addRect(view.bounds)
+    mutablePath.addArc(center: center, radius: radius, startAngle: 0.0, endAngle: 2 * 3.14, clockwise: false)
+    
+    let mask = CAShapeLayer()
+    mask.path = mutablePath
+    mask.fillRule = kCAFillRuleEvenOdd
+    
+    view.layer.mask = mask
   }
   
   /// A background view which add ripple animation when showing target view
@@ -316,6 +336,7 @@ extension MaterialShowcase {
     addSubview(targetRippleView)
     
   }
+	
   
   /// A circle-shape background view of target view
   private func addTargetHolder(at center: CGPoint) {

--- a/MaterialShowcase/Utility.swift
+++ b/MaterialShowcase/Utility.swift
@@ -105,9 +105,8 @@ extension UIViewKeyframeAnimationOptions {
   }
   
   init(animationOptions: UIViewAnimationOptions) {
-    rawValue = animationOptions.rawValue
+    self.init(rawValue: animationOptions.rawValue)
   }
-  
 }
 
 extension CGRect {


### PR DESCRIPTION
If the targetHolderColor property is set to UIColor.clear, then the target snapshot is not created. This allows the targetView to be shown through the background view.

If the targetHolderColor property is set to any color other than UIColor.clear, then the target snapshot is created and added to the view.