### PR TITLE
Fix problem for overlapping primary and secondary label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 ==========
+Version 0.6.4 *(2018-11-10)*
+-------------------------------
+* Fix issue #74 and #81 for overlapping primary and secondary label when some libraries overriding the UIView control.
+
 Version 0.6.3 *(2018-09-30)*
 -------------------------------
 * Update to Swift 4.2

--- a/MaterialShowcase.podspec
+++ b/MaterialShowcase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = 'MaterialShowcase'
-s.version          = '0.6.3'
+s.version          = '0.6.4'
 s.summary          = 'An elegant and beautiful showcase for iOS apps.'
 
 s.description      = <<-DESC

--- a/MaterialShowcase/MaterialShowcaseInstructionView.swift
+++ b/MaterialShowcase/MaterialShowcaseInstructionView.swift
@@ -62,6 +62,10 @@ public class MaterialShowcaseInstructionView: UIView {
   
   /// Configures and adds primary label view
   private func addPrimaryLabel() {
+    if primaryLabel != nil {
+        primaryLabel.removeFromSuperview()
+    }
+    
     primaryLabel = UILabel()
     
     if let font = primaryTextFont {
@@ -98,6 +102,10 @@ public class MaterialShowcaseInstructionView: UIView {
   
   /// Configures and adds secondary label view
   private func addSecondaryLabel() {
+    if secondaryLabel != nil {
+        secondaryLabel.removeFromSuperview()
+    }
+    
     secondaryLabel = UILabel()
     if let font = secondaryTextFont {
       secondaryLabel.font = font

--- a/MaterialShowcase/MaterialShowcaseInstructionView.swift
+++ b/MaterialShowcase/MaterialShowcaseInstructionView.swift
@@ -124,7 +124,7 @@ public class MaterialShowcaseInstructionView: UIView {
                                   height: 0)
     secondaryLabel.sizeToFitHeight()
     addSubview(secondaryLabel)
-    frame = CGRect(x: frame.minX, y: frame.minY, width: getWidth(), height: primaryLabel.frame.height + secondaryLabel.frame.height)
+    frame = CGRect(x: frame.minX, y: frame.minY, width: frame.width, height: primaryLabel.frame.height + secondaryLabel.frame.height)
   }
   
   //Calculate width per device


### PR DESCRIPTION
* Fix issue #74 and #81 concerning primary and secondary label overlap when some libraries override UIView control methods.

Thanks to @hrsalehi