### PR TITLE
MaterialShowcase: Check for keyWindow instead of delegate window

### DIFF
--- a/MaterialShowcase/MaterialShowcase.swift
+++ b/MaterialShowcase/MaterialShowcase.swift
@@ -184,10 +184,10 @@ extension MaterialShowcase {
   /// Returns the current showcases displayed on screen.
   /// It will return null if no showcase exists.
   public static func presentedShowcases() -> [MaterialShowcase]? {
-    guard let window = UIApplication.shared.delegate?.window else {
+    guard let window = UIApplication.shared.keyWindow else {
       return nil
     }
-    return window?.subviews.filter({ (view) -> Bool in
+    return window.subviews.filter({ (view) -> Bool in
       return view is MaterialShowcase
     }) as? [MaterialShowcase]
   }
@@ -199,7 +199,7 @@ extension MaterialShowcase {
   /// Initializes default view properties
   func configure() {
     backgroundColor = UIColor.clear
-    guard let window = UIApplication.shared.delegate?.window else {
+    guard let window = UIApplication.shared.keyWindow else {
       return
     }
     containerView = window


### PR DESCRIPTION
It is not necessary to use window provided by AppDelegate, instead check for key window