### PR TITLE
Fixes for positioning instruction view according to text height

### DIFF
--- a/MaterialShowcase/MaterialShowcase.swift
+++ b/MaterialShowcase/MaterialShowcase.swift
@@ -483,22 +483,38 @@ extension MaterialShowcase {
     var width : CGFloat
     
     if UIDevice.current.userInterfaceIdiom == .pad {
+      backgroundView.addSubview(instructionView)
+    } else {
+      addSubview(instructionView)
+    }
+      
+    instructionView.layoutIfNeeded()
+    
+    if UIDevice.current.userInterfaceIdiom == .pad {
       width = backgroundView.frame.width - 2 * xPosition
       
       if backgroundView.frame.origin.x < 0 {
         xPosition = abs(backgroundView.frame.origin.x) + xPosition
       } else if (backgroundView.frame.origin.x + backgroundView.frame.size.width >
         UIScreen.main.bounds.width) {
-        width = backgroundView.frame.size.width - (xPosition*2)
+        xPosition = 2 * LABEL_MARGIN
+        width = backgroundView.frame.size.width - (backgroundView.frame.maxX - UIScreen.main.bounds.width) - xPosition - LABEL_MARGIN
       }
       if xPosition + width > backgroundView.frame.size.width {
         width = width - CGFloat(xPosition/2)
       }
       
+      //Updates horizontal parameters
+      instructionView.frame = CGRect(x: xPosition,
+                                   y: instructionView.frame.origin.y,
+                                   width: width,
+                                   height: 0)
+      instructionView.layoutIfNeeded()
+      
       if getTargetPosition(target: targetView, container: containerView) == .above {
         yPosition = (backgroundView.frame.size.height/2) + TEXT_CENTER_OFFSET
       } else {
-        yPosition = TEXT_CENTER_OFFSET + LABEL_DEFAULT_HEIGHT * 2
+        yPosition = (backgroundView.frame.size.height/2) - TEXT_CENTER_OFFSET - instructionView.frame.height
       }
     } else {
       width = containerView.frame.size.width - (xPosition*2)
@@ -510,10 +526,17 @@ extension MaterialShowcase {
         xPosition = xPosition + abs(backgroundView.frame.origin.x)
       }
       
+      //Updates horizontal parameters
+      instructionView.frame = CGRect(x: xPosition,
+                                   y: instructionView.frame.origin.y,
+                                   width: width ,
+                                   height: 0)
+      instructionView.layoutIfNeeded()
+      
       if getTargetPosition(target: targetView, container: containerView) == .above {
         yPosition = center.y + TARGET_PADDING +  (targetView.bounds.height / 2 > targetHolderRadius ? targetView.bounds.height / 2 : targetHolderRadius)
       } else {
-        yPosition = center.y - TEXT_CENTER_OFFSET - LABEL_DEFAULT_HEIGHT * 2
+        yPosition = center.y - TEXT_CENTER_OFFSET - max(instructionView.frame.height,LABEL_DEFAULT_HEIGHT * 2)
       }
       
     }
@@ -522,11 +545,6 @@ extension MaterialShowcase {
                                    y: yPosition,
                                    width: width ,
                                    height: 0)
-    if UIDevice.current.userInterfaceIdiom == .pad {
-      backgroundView.addSubview(instructionView)
-    } else {
-      addSubview(instructionView)
-    }
   }
   
   /// Handles user's tap

--- a/MaterialShowcase/MaterialShowcaseInstructionView.swift
+++ b/MaterialShowcase/MaterialShowcaseInstructionView.swift
@@ -80,7 +80,7 @@ public class MaterialShowcaseInstructionView: UIView {
     primaryLabel.text = primaryText
     primaryLabel.frame = CGRect(x: 0,
                                 y: 0,
-                                width: getWidth(),
+                                width: frame.width,
                                 height: 0)
 
     primaryLabel.sizeToFitHeight()
@@ -107,24 +107,13 @@ public class MaterialShowcaseInstructionView: UIView {
     
     secondaryLabel.frame = CGRect(x: 0,
                                   y: primaryLabel.frame.height,
-                                  width: getWidth(),
+                                  width: frame.width,
                                   height: 0)
     secondaryLabel.sizeToFitHeight()
     addSubview(secondaryLabel)
     frame = CGRect(x: frame.minX, y: frame.minY, width: frame.width, height: primaryLabel.frame.height + secondaryLabel.frame.height)
   }
   
-  //Calculate width per device
-  private func getWidth() -> CGFloat {
-    //superview was left side
-    if (self.superview?.frame.origin.x)! < CGFloat(0) {
-      return frame.width - (frame.minX/2)
-    } else if ((self.superview?.frame.origin.x)! + (self.superview?.frame.size.width)! >
-      UIScreen.main.bounds.width) { //superview was right side
-      return (frame.width - frame.minX)/2
-    }
-    return frame.width
-  }
   
   /// Overrides this to add subviews. They will be drawn when calling show()
   public override func layoutSubviews() {


### PR DESCRIPTION
Fixes made to positioning instruction view using its height when instruction view is below the target.

Fixes made to positioning instruction view correctly in iPad when backgroundView is outer of the right side of the screen.