### PR TITLE
Fixing text layout case on iPad

### DIFF
--- a/Sources/MaterialShowcase/MaterialShowcase.swift
+++ b/Sources/MaterialShowcase/MaterialShowcase.swift
@@ -504,7 +504,7 @@ extension MaterialShowcase {
         width = backgroundView.frame.size.width - (backgroundView.frame.maxX - UIScreen.main.bounds.width) - xPosition - LABEL_MARGIN
       }
       if xPosition + width > backgroundView.frame.size.width {
-        width = width - CGFloat(xPosition/2)
+        width = backgroundView.frame.size.width - xPosition - (LABEL_MARGIN * 2)
       }
       
       //Updates horizontal parameters


### PR DESCRIPTION
This change I made came out of an issue with iPad where the layout code for the text fields didn't seem to work well on the right side of the screen. I rewrote a line I didn't quite understand based on what logically I thought was the intent of the line. I wrote a tool to replicate the issue as well, and verified that I didn't encounter any regressions. Below are my before and after results: 

Before:
![Screen Shot 2020-12-14 at 1 26 02 PM](https://user-images.githubusercontent.com/1676539/102134772-9bdeac00-3e1c-11eb-9014-ebe4ea171e25.png)


After:
![Screen Shot 2020-12-14 at 1 26 56 PM](https://user-images.githubusercontent.com/1676539/102134808-a5681400-3e1c-11eb-91b7-589a3d90ef6d.png)

