### PR TITLE
Fixed crash TabBar changing index when tapThrough is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 ==========
+Version 0.9.0 *(2022-08-01)*
+--------------------------------
+* Supported new overload for setTargetView for UITabBarController item to fix the issue #118
+
 Version 0.8.0 *(2021-03-25)*
 --------------------------------
 * Add the feature that is able to "Skip" showcase

--- a/MaterialShowcase.podspec
+++ b/MaterialShowcase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = 'MaterialShowcase'
-s.version          = '0.8.0'
+s.version          = '0.9.0'
 s.summary          = 'An elegant and beautiful showcase for iOS apps.'
 
 s.description      = <<-DESC

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ brew install carthage
 
 To integrate MaterialShowcase into your Xcode project using Carthage, specify it in your `Cartfile`:
 ```ogdl
-github "aromajoin/material-showcase-ios" ~> 0.8.0
+github "aromajoin/material-showcase-ios" ~> 0.9.0
 ```
 
 Run `carthage update` to build the framework and drag the built `MaterialShowcase.framework` into your Xcode project.
@@ -86,6 +86,8 @@ By default, tapping a showcase's target does not perform it's predefined action.
   showcase.setTargetView(barButtonItem: barItem, tapThrough: true)
   // UITabBar item
   showcase.setTargetView(tabBar: tabBar, itemIndex: 0, tapThrough: true)
+  // UITabBarController
+  showcase.setTargetView(tabBarController: tabBarViewController, itemIndex: 0, tapThrough: true)
 ```
 
 ### Handle showcase status

--- a/Sources/MaterialShowcase/MaterialShowcase.swift
+++ b/Sources/MaterialShowcase/MaterialShowcase.swift
@@ -193,6 +193,22 @@ extension MaterialShowcase {
     }
   }
   
+  @objc public func setTargetView(tabBarController: UITabBarController, itemIndex: Int, tapThrough: Bool = false) {
+    let tabBar = tabBarController.tabBar
+    
+    let tabBarItems = orderedTabBarItemViews(of: tabBar)
+    if itemIndex < tabBarItems.count {
+      targetView = tabBarItems[itemIndex]
+      targetTintColor = tabBar.tintColor
+      backgroundPromptColor = tabBar.tintColor
+      if tapThrough {
+        onTapThrough = { tabBarController.selectedIndex = itemIndex}
+      }
+    } else {
+      print ("The tab bar controller item index is out of range")
+    }
+  }
+  
   /// Sets a UITableViewCell as target
   @objc public func setTargetView(tableView: UITableView, section: Int, row: Int) {
     let indexPath = IndexPath(row: row, section: section)


### PR DESCRIPTION
- Supported new overload for setTargetView for UITabBarController item to fix the (#118) issue